### PR TITLE
S2EExecutor: onStateForkDecide signal incorrectly emitted

### DIFF
--- a/include/s2e/CorePlugin.h
+++ b/include/s2e/CorePlugin.h
@@ -31,9 +31,11 @@ namespace s2e {
 
 class S2EExecutionState;
 
-/** A type of a signal emitted on instruction execution. Instances of this signal
-    will be dynamically created and destroyed on demand during translation. */
-typedef sigc::signal<void, S2EExecutionState *, uint64_t /* pc */> ExecutionSignal;
+///
+/// A type of a signal emitted on instruction execution. Instances of this signal will be dynamically created and
+/// destroyed on demand during translation.
+///
+typedef sigc::signal<void, S2EExecutionState *, uint64_t /* PC */> ExecutionSignal;
 
 class CorePlugin : public Plugin {
     S2E_PLUGIN
@@ -52,66 +54,75 @@ public:
     // clang-format off
 
     ///
-    /// \brief onEngineShutdown is emitted when there are no more states
-    /// to run and S2E is going to shutdown.
+    /// \brief Emitted when there are no more states to run and S2E is going to shutdown.
     ///
-    /// The engine calls this signal before plugins are destroyed.
-    /// Gives a chance for plugins to clean up their state.
+    /// The engine calls this signal before plugins are destroyed. This gives a chance for plugins to clean up their
+    /// state.
     ///
     sigc::signal<void> onEngineShutdown;
 
 
-    /** Signal that is emitted on beginning and end of code generation
-        for each translation block.
-    */
-    sigc::signal<void, ExecutionSignal*,
-            S2EExecutionState*,
-            TranslationBlock*,
-            uint64_t /* block PC */>
-            onTranslateBlockStart;
+    ///
+    /// Signal that is emitted on beginning and end of code generation for each translation block.
+    ///
+    sigc::signal<void,
+                 ExecutionSignal*,
+                 S2EExecutionState*,
+                 TranslationBlock*,
+                 uint64_t /* block PC */>
+        onTranslateBlockStart;
 
-    /**
-     * Signal that is emitted upon end of a translation block.
-     * If the end is a conditional branch, it is emitted for both outcomes.
-     */
-    sigc::signal<void, ExecutionSignal*,
-            S2EExecutionState*,
-            TranslationBlock*,
-            uint64_t /* ending instruction pc */,
-            bool /* static target is valid */,
-            uint64_t /* static target pc */>
-            onTranslateBlockEnd;
+    ///
+    /// Signal that is emitted upon end of a translation block. If the end is a conditional branch, it is emitted for
+    /// both outcomes.
+    ///
+    sigc::signal<void,
+                 ExecutionSignal*,
+                 S2EExecutionState*,
+                 TranslationBlock*,
+                 uint64_t /* ending instruction PC */,
+                 bool /* static target is valid */,
+                 uint64_t /* static target PC */>
+        onTranslateBlockEnd;
 
-    /**
-     * Signal that is emitted when the translator finishes
-     * translating the block.
-     */
-    sigc::signal<void, S2EExecutionState*,
-            TranslationBlock*,
-            uint64_t /* ending instruction pc */>
-            onTranslateBlockComplete;
+    ///
+    /// Signal that is emitted when the translator finishes translating the block.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
+                 TranslationBlock*,
+                 uint64_t /* ending instruction PC */>
+        onTranslateBlockComplete;
 
+    ///
+    /// Signals that are emitted on code generation for each instruction.
+    ///
+    sigc::signal<void,
+                 ExecutionSignal*,
+                 S2EExecutionState*,
+                 TranslationBlock*,
+                 uint64_t /* instruction PC */>
+        onTranslateInstructionStart, onTranslateInstructionEnd;
 
-    /** Signal that is emitted on code generation for each instruction */
-    sigc::signal<void, ExecutionSignal*,
-            S2EExecutionState*,
-            TranslationBlock*,
-            uint64_t /* instruction PC */>
-            onTranslateInstructionStart, onTranslateInstructionEnd;
+    ///
+    /// \brief Signal that is emitted at the end of "special" instructions.
+    ///
+    /// These special instructions include syscalls, immediate push instructions and reading rdtsc.
+    ///
+    sigc::signal<void,
+                 ExecutionSignal*,
+                 S2EExecutionState*,
+                 TranslationBlock*,
+                 uint64_t /* instruction PC */,
+                enum special_instruction_t  /* instruction type */>
+        onTranslateSpecialInstructionEnd;
 
-    sigc::signal<void, ExecutionSignal*,
-            S2EExecutionState*,
-            TranslationBlock*,
-            uint64_t /* instruction PC */,
-            enum special_instruction_t  /* instruction type */>
-            onTranslateSpecialInstructionEnd;
-
-    /**
-     *  Triggered *after* each instruction is translated to notify
-     *  plugins of which registers are used by the instruction.
-     *  Each bit of the mask corresponds to one of the registers of
-     *  the architecture (e.g., R_EAX, R_ECX, etc).
-     */
+    ///
+    /// Triggered \b after each instruction is translated to notify plugins of which registers are used by the
+    /// instruction.
+    ///
+    /// Each bit of the mask corresponds to one of the registers of the architecture (e.g., R_EAX, R_ECX, etc).
+    ///
     sigc::signal<void,
                  ExecutionSignal*,
                  S2EExecutionState* /* current state */,
@@ -122,240 +133,321 @@ public:
                  bool /* instruction accesses memory */>
           onTranslateRegisterAccessEnd;
 
-    /** Signal that is emitted on code generation for each jump instruction */
-    sigc::signal<void, ExecutionSignal*,
-            S2EExecutionState*,
-            TranslationBlock*,
-            uint64_t /* instruction PC */,
-            int /* jump_type */>
-            onTranslateJumpStart;
+    ///
+    /// Signal that is emitted on code generation for each jump instruction.
+    ///
+    sigc::signal<void,
+                 ExecutionSignal*,
+                 S2EExecutionState*,
+                 TranslationBlock*,
+                 uint64_t /* instruction PC */,
+                 int /* jump type */>
+        onTranslateJumpStart;
 
-    /** Signal that is emitted on code generation for each indirect CTI instruction */
-    sigc::signal<void, ExecutionSignal*,
-            S2EExecutionState*,
-            TranslationBlock*,
-            uint64_t /* instruction PC */,
-            int /* rm */,
-            int /* op */,
-            int /* offset */ >
-            onTranslateICTIStart;
+    ///
+    /// Signal that is emitted on code generation for each indirect CTI instruction.
+    ///
+    sigc::signal<void,
+                 ExecutionSignal*,
+                 S2EExecutionState*,
+                 TranslationBlock*,
+                 uint64_t /* instruction PC */,
+                 int /* rm */,
+                 int /* op */,
+                 int /* offset */>
+        onTranslateICTIStart;
 
-    /** Signal that is emitted on code generation for LEA instruction with
-        a rip-relative offset */
-    sigc::signal<void, ExecutionSignal*,
-            S2EExecutionState*,
-            TranslationBlock*,
-            uint64_t /* instruction PC */,
-            uint64_t /* target address */>
-            onTranslateLeaRipRelative;
+    ///
+    /// Signal that is emitted on code generation for LEA instructions with a RIP-relative offset.
+    ///
+    sigc::signal<void,
+                 ExecutionSignal*,
+                 S2EExecutionState*,
+                 TranslationBlock*,
+                 uint64_t /* instruction PC */,
+                 uint64_t /* target address */>
+        onTranslateLeaRipRelative;
 
-    /** Signal that is emitted upon exception */
-    sigc::signal<void, S2EExecutionState*,
-            unsigned /* Exception Index */,
-            uint64_t /* pc */>
-            onException;
+    ///
+    /// Signal that is emitted upon exception.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
+                 unsigned /* Exception Index */,
+                 uint64_t /* PC */>
+        onException;
 
-    /** Signal that is emitted when custom opcode is detected */
-    sigc::signal<void, S2EExecutionState*,
-            uint64_t  /* arg */
-            >
-            onCustomInstruction;
+    ///
+    /// Signal that is emitted when custom opcode is detected.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
+                 uint64_t /* arg */>
+        onCustomInstruction;
 
-    /** Signal emitted right before an int xxx instruction is translated */
+    ///
+    /// Signal emitted right before an INT xxx instruction is translated.
+    ///
     sigc::signal<void,
                  ExecutionSignal*,
                  S2EExecutionState* /* current state */,
                  TranslationBlock*,
                  uint64_t /* program counter of the instruction */,
                  unsigned /* the interrupt vector */>
-          onTranslateSoftInterruptStart;
+        onTranslateSoftInterruptStart;
 
-    /** Signal that is emitted before accessing memory at symbolic address */
-    sigc::signal<void, S2EExecutionState*,
-                 klee::ref<klee::Expr> /* virtualAddress */,
+    ///
+    /// Signal that is emitted before accessing memory at symbolic address.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
+                 klee::ref<klee::Expr> /* virtual address */,
                  klee::ref<klee::Expr> /* value */,
-                 bool> /* isWrite */
-            onBeforeSymbolicDataMemoryAccess;
+                 bool /* is write */>
+        onBeforeSymbolicDataMemoryAccess;
 
-    /** Signal that is emitted on each memory access */
-    /* XXX: this signal is still not emitted for code */
-    /* Important: when the MEM_TRACE_FLAG_PRECISE is not set,
-       the reported program counter in the execution state is
-       not synchronized and the handler must not attempt to exit the cpu loop
-       or tweak the control flow */
-    sigc::signal<void, S2EExecutionState*,
-                 klee::ref<klee::Expr> /* virtualAddress */,
-                 klee::ref<klee::Expr> /* hostAddress */,
+    ///
+    /// \brief Signal that is emitted on each memory access.
+    ///
+    /// Note that this signal is still not emitted for code.
+    ///
+    /// Important: when the \c MEM_TRACE_FLAG_PRECISE is not set, the reported program counter in the execution state
+    /// is not synchronized and the handler must not attempt to exit the cpu loop or tweak the control flow.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
+                 klee::ref<klee::Expr> /* virtual address */,
+                 klee::ref<klee::Expr> /* host address */,
                  klee::ref<klee::Expr> /* value */,
                  unsigned /* flags */>
-            onAfterSymbolicDataMemoryAccess;
+        onAfterSymbolicDataMemoryAccess;
 
-    /**
-     * Signal emitted before handling a memory address.
-     * - The concrete address is one example of an address that satisfies
-     * the constraints.
-     * - The concretize flag can be set to ask the engine to concretize the address.
-     */
-    sigc::signal<void, S2EExecutionState*,
-                 klee::ref<klee::Expr> /* virtualAddress */,
-                 uint64_t /* concreteAddress */,
-                 bool & /* concretize */,
-                 CorePlugin::symbolicAddressReason /* reason */ >
-            onSymbolicAddress;
+    ///
+    /// \brief Signal emitted before handling a memory address.
+    ///
+    /// \li The concrete address is one example of an address that satisfies the constraints.
+    /// \li The concretize flag can be set to ask the engine to concretize the address.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
+                 klee::ref<klee::Expr> /* virtual address */,
+                 uint64_t /* concrete address */,
+                 bool& /* concretize */,
+                 CorePlugin::symbolicAddressReason /* reason */>
+        onSymbolicAddress;
 
-    /* Optimized signal for concrete accesses */
-    sigc::signal<void, S2EExecutionState*,
-                 uint64_t /* virtualAddress */,
+    ///
+    /// Optimized signal for concrete accesses.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
+                 uint64_t /* virtual address */,
                  uint64_t /* value */,
                  uint8_t /* size */,
                  unsigned /* flags */>
-            onConcreteDataMemoryAccess;
+        onConcreteDataMemoryAccess;
 
-
-    /** Signal that is emitted on each port access */
-    sigc::signal<void, S2EExecutionState*,
+    ///
+    /// Signals that are emitted on each port access.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
                  klee::ref<klee::Expr> /* port */,
                  klee::ref<klee::Expr> /* value */,
-                 bool /* isWrite */>
-            onPortAccess;
+                 bool /* is write */>
+        onPortAccess;
 
-    sigc::signal<void, S2EExecutionState*,
+    ///
+    // Emitted when a symbolic variable is created.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
                  const std::string & /* orignal name */,
-                 const std::vector<klee::ref<klee::Expr> > &, /* expr */
+                 const std::vector<klee::ref<klee::Expr>>&, /* expr */
                  const klee::MemoryObject*,
-                 const klee::Array*
-                 >
-            onSymbolicVariableCreation;
+                 const klee::Array*>
+        onSymbolicVariableCreation;
 
+    ///
+    /// Emitted periodically every 1000 ms.
+    ///
     sigc::signal<void> onTimer;
 
-    /** Signal emitted when the state is forked */
-    sigc::signal<void, S2EExecutionState* /* originalState */,
-                 const std::vector<S2EExecutionState*>& /* newStates */,
-                 const std::vector<klee::ref<klee::Expr> >& /* newConditions */>
-            onStateFork;
-
-    /** Signal that is emitted when two states are merged */
-    sigc::signal<void, S2EExecutionState* /* destination */,
-                 S2EExecutionState* /* source */>
-            onStateMerge;
-
+    ///
+    /// Signal emitted when the state is forked.
+    ///
     sigc::signal<void,
-                 S2EExecutionState*, /* currentState */
-                 S2EExecutionState*> /* nextState */
-            onStateSwitch;
+                 S2EExecutionState* /* original state */,
+                 const std::vector<S2EExecutionState*>& /* new states */,
+                 const std::vector<klee::ref<klee::Expr>>& /* new conditions */>
+        onStateFork;
 
-    /**
-     * Triggered whenever a state is killed
-     */
+    ///
+    /// Signal that is emitted when two states are merged.
+    //
+    sigc::signal<void,
+                 S2EExecutionState* /* destination */,
+                 S2EExecutionState* /* source */>
+        onStateMerge;
+
+    ///
+    /// Signal that is emitted when we change states.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*, /* current state */
+                 S2EExecutionState* /* next state */>
+        onStateSwitch;
+
+    ///
+    /// Triggered whenever a state is killed.
+    ///
     sigc::signal<void, S2EExecutionState*> onStateKill;
 
 
-    /**
-     * The executor emits this signal when it is about to fork a process.
-     * Last chance to stop it.
-     * Plugins set the pointer to true to allow forking to proceed.
-     */
-    sigc::signal<void, bool*> onProcessForkDecide;
-
-
-    /**
-     * The executor emits this signal when it is about to fork a new state.
-     * Last chance to stop it.
-     * Plugins set the pointer to true to allow forking to proceed.
-     */
-    sigc::signal<void, S2EExecutionState *, bool*> onStateForkDecide;
-
-
-    /** Signal emitted when spawning a new S2E process */
-    sigc::signal<void, bool /* prefork */,
-                bool /* ischild */,
-                unsigned /* parentProcId */>
-            onProcessFork;
-
-    /**
-     * Signal emitted when the load balancing needs to terminate states in
-     * the parent or the child. This allows plugins to change the default policy
-     * of splitting them in half by moving/copying the states in
-     * the desired sets.
-     */
+    ///
+    /// The executor emits this signal when it is about to fork a process. This is the last chance to stop it.
+    ///
+    /// Plugins set the pointer to \c true to allow forking to proceed.
+    ///
     sigc::signal<void,
-                 klee::StateSet & /* parent */,
-                 klee::StateSet & /* child */>
-            onStatesSplit;
-
-    /**
-     * Signal emitted when a new S2E process was spawned and all
-     * parent states were removed from the child and child states
-     * removed from the parent.
-     */
-    sigc::signal<void, bool /* isChild */> onProcessForkComplete;
+                 bool* /* allow forking */>
+        onProcessForkDecide;
 
 
-    /** Signal that is emitted upon TLB miss */
-    sigc::signal<void, S2EExecutionState*, uint64_t, bool> onTlbMiss;
+    ///
+    /// \brief The executor emits this signal when it is about to fork a new state. This is the last chance to stop it.
+    ///
+    /// Note that this signal may be emitted when executing program instructions that are \b not necessarily branch
+    /// instructions. For example, when dereferencing symbolic memory a number of helper functions are called (see
+    /// \c TCGLLVMContextPrivate::initialzeHelpers) which may also cause fork branches. Depending on: the program
+    /// instruction; memory accessed; and helper functions called, this may cause \c onStateForkDecide to be emitted
+    /// multiple times for the same execution of a program instruction.
+    ///
+    /// Some optimization is performed so that the signal is \b not emitted when the fork condition is a constant
+    /// expression (see \c S2EExecutor::fork). However, there may still be instances when the \c onStateForkDecide
+    /// signal is emitted and fork branches are not actually guaranteed to occur (e.g. the constraint solver may decide
+    /// not to fork branches).
+    ///
+    /// It is up to the signal handler to handle these cases. The signal handler <b>must not</b> assume that:
+    ///
+    ///   \li The fork is occurring at a branch instruction in the program code
+    ///   \li The fork will actually occur, even if the pointer is set to \c true (ultimately this is up to the
+    ///       constraint solver)
+    ///   \li The signal will only be emitted once when a program instruction that \a may fork is executed.
+    ///
+    /// Plugins set the pointer to \c true to allow forking to proceed. By default this is set to \c true.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
+                 bool* /* allow forking */>
+        onStateForkDecide;
 
-    /** Signal that is emitted upon page fault */
-    sigc::signal<void, S2EExecutionState*, uint64_t, bool> onPageFault;
 
-    /**
-     * The current execution privilege level was changed (e.g., kernel-mode=>user-mode)
-     * previous and current are privilege levels. The meaning of the value may
-     * depend on the architecture.
-     */
+    ///
+    /// Signal emitted when spawning a new S2E process.
+    ///
+    sigc::signal<void,
+                 bool /* prefork */,
+                 bool /* is child */,
+                 unsigned /* parent process ID */>
+        onProcessFork;
+
+    ///
+    /// \brief Signal emitted when the load balancing needs to terminate states in the parent or the child.
+    ///
+    /// This signal allows plugins to change the default policy of splitting them in half by moving/copying the states
+    /// in the desired sets.
+    ///
+    sigc::signal<void,
+                 klee::StateSet& /* parent */,
+                 klee::StateSet& /* child */>
+        onStatesSplit;
+
+    ///
+    /// Signal emitted when a new S2E process was spawned and all parent states were removed from the child and child
+    /// states removed from the parent.
+    //
+    sigc::signal<void,
+                 bool /* is child */>
+        onProcessForkComplete;
+
+    ///
+    /// Signal that is emitted upon TLB miss.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
+                 uint64_t /* address */,
+                 bool /* is write */>
+        onTlbMiss;
+
+    ///
+    /// Signal that is emitted upon page fault.
+    ///
+    sigc::signal<void,
+                 S2EExecutionState*,
+                 uint64_t /* address */,
+                 bool /* is write */>
+        onPageFault;
+
+    ///
+    /// \brief Emitted when the current execution privilege level was changed (e.g., kernel-mode to user-mode).
+    ///
+    /// The meaning of the current and previous privilege level may depend on the architecutre.
+    ///
     sigc::signal<void,
                  S2EExecutionState* /* current state */,
                  unsigned /* previous level */,
                  unsigned /* current level */>
-          onPrivilegeChange;
+        onPrivilegeChange;
 
-    /**
-     * The current page directory was changed.
-     * This may occur, e.g., when the OS swaps address spaces.
-     * The addresses correspond to physical addresses.
-     */
+    ///
+    /// \brief The current page directory was changed.
+    ///
+    /// This may occur, e.g., when the OS swaps address spaces. The addresses correspond to physical addresses.
+    ///
     sigc::signal<void,
                  S2EExecutionState* /* current state */,
                  uint64_t /* previous page directory base */,
                  uint64_t /* current page directory base */>
-          onPageDirectoryChange;
+        onPageDirectoryChange;
 
-    /**
-     * S2E completed initialization and is about to enter
-     * the main execution loop for the first time.
-     */
+    ///
+    /// S2E completed initialization and is about to enter the main execution loop for the first time.
+    ///
     sigc::signal<void,
-                 S2EExecutionState* /* current state */>
-          onInitializationComplete;
+                 S2EExecutionState*>
+        onInitializationComplete;
 
-    /**
-     * Exposes the equivalent searcher API call to S2E plugins.
-     * Plugins can cleanup their structures with this.
-     * The subscribers MUST NOT throw exceptions.
-     */
+    ///
+    /// \brief Exposes the equivalent searcher API call to S2E plugins.
+    ///
+    /// Plugins can cleanup their structures with this signal. The subscribers <b>MUST NOT</b> throw exceptions.
+    ///
     sigc::signal<void,
-                 S2EExecutionState* /* current state */,
-                 const klee::StateSet & /* addedStates */,
-                 const klee::StateSet & /* removedStates */>
-          onUpdateStates;
+                 S2EExecutionState*,
+                 const klee::StateSet& /* added states */,
+                 const klee::StateSet& /* removed states */>
+        onUpdateStates;
 
-    /**
-     * Fired when the klee::AddressSpace is changed.
-     */
+    ///
+    /// Emitted when the \c klee::AddressSpace is changed.
+    ///
     sigc::signal<void,
-                 S2EExecutionState* /* current state */,
-                 const klee::MemoryObject* /* *mo */,
-                 const klee::ObjectState* /* *oldState */,
-                 klee::ObjectState* /* *newState */>
-          onAddressSpaceChange;
+                 S2EExecutionState*,
+                 const klee::MemoryObject*,
+                 const klee::ObjectState* /* old state */,
+                 klee::ObjectState* /* new state */>
+        onAddressSpaceChange;
 
-
+    ///
+    /// Emitted when a function call return instruction is translated.
+    ///
     sigc::signal<void,
                 S2EExecutionState*,
-                uint64_t /* pc */,
-                bool /* isCall */,
+                uint64_t /* PC */,
+                bool /* is call */,
                 bool * /* instrument */>
-          onCallReturnTranslate;
+        onCallReturnTranslate;
 
     // clang-format on
 };

--- a/src/S2EExecutor.cpp
+++ b/src/S2EExecutor.cpp
@@ -2069,12 +2069,15 @@ S2EExecutor::StatePair S2EExecutor::fork(ExecutionState &current, klee::ref<Expr
 
     StatePair res;
 
-    if (currentState->forkDisabled && !dyn_cast<klee::ConstantExpr>(condition)) {
-        g_s2e->getDebugStream(currentState) << "fork disabled\n";
-    }
-
+    // If the condition is constant, there is no need to do anything as the fork will not branch
     bool forkOk = true;
-    g_s2e->getCorePlugin()->onStateForkDecide.emit(currentState, &forkOk);
+    if (!dyn_cast<klee::ConstantExpr>(condition)) {
+        if (currentState->forkDisabled) {
+            g_s2e->getDebugStream(currentState) << "fork disabled\n";
+        }
+
+        g_s2e->getCorePlugin()->onStateForkDecide.emit(currentState, &forkOk);
+    }
 
     bool oldForkStatus = currentState->forkDisabled;
     if (!forkOk && !currentState->forkDisabled) {


### PR DESCRIPTION
The `onStateForkDecide` signal is spuriously emitted. The reason is as follows:

KLEE will call `S2EExecutor::fork` regardless of the branch's condition being a symbolic expression or concrete value. It is not until `klee::Executor::concolicFork` and `klee::Executor::fork` that the condition is checked and a fork performed **only** if the condition is **not** a `klee::ConstantExpr`.

However, the `onStateForkDecide` signal is emitted **before** this check for a `klee::ConstantExpr` is actually made. This signal is emitted unconditionally, which means that it will occur for every branch instruction in LLVM code, regardless of whether it depends on a symbolic expression or not.

For example, this can cause the following problem. If the program counter is checked in the `onStateForkDecide` signal handler, it may show addresses that correspond to instructions that are not necessarily branch instructions. This is because functions like `__ldb_mmu` (which get inserted into the generated LLVM code when performing a memory read) also contain conditional branches that have nothing to do with symbolic values. For example, one check is that `*g_sqi.events.before_memory_access_signals_count != NULL`. This branch condition has no symbolic expressions, however `S2EExecutor::fork` will still be called and the `onStateForkDecide` signal will still be emitted. This may lead to incorrect state fork decisions (e.g. if you are basing your decision on the program counter).

To fix this problem we restrict the `onStateForkDecide` signal so that it is only emitted when the branching condition is based on a non-constant symbolic expression.