### PR TITLE
S2EExecutionState: set address in onSymbolicVariableCreation's MemoryObject

### DIFF
--- a/include/s2e/S2EExecutionState.h
+++ b/include/s2e/S2EExecutionState.h
@@ -264,7 +264,8 @@ public:
     klee::ref<klee::Expr> createSymbolicValue(const std::string &name = std::string(),
                                               klee::Expr::Width width = klee::Expr::Int32);
 
-    std::vector<klee::ref<klee::Expr>> createSymbolicArray(const std::string &name = std::string(), unsigned size = 4,
+    std::vector<klee::ref<klee::Expr>> createSymbolicArray(const std::string &name = std::string(),
+                                                           uintptr_t address = 0, unsigned size = 4,
                                                            std::string *varName = NULL);
 
     /** Create a symbolic value tied to an example concrete value */
@@ -288,7 +289,7 @@ public:
         return createConcolicValue(name, sizeof(T) * 8, concolicValue);
     }
 
-    std::vector<klee::ref<klee::Expr>> createConcolicArray(const std::string &name, unsigned size,
+    std::vector<klee::ref<klee::Expr>> createConcolicArray(const std::string &name, uintptr_t address, unsigned size,
                                                            const std::vector<unsigned char> &concreteBuffer,
                                                            std::string *varName = NULL);
 

--- a/src/S2EExecutionState.cpp
+++ b/src/S2EExecutionState.cpp
@@ -311,7 +311,7 @@ ref<Expr> S2EExecutionState::createSymbolicValue(const std::string &name, Expr::
     return createConcolicValue(name, width, concreteValues);
 }
 
-std::vector<ref<Expr>> S2EExecutionState::createConcolicArray(const std::string &name, unsigned size,
+std::vector<ref<Expr>> S2EExecutionState::createConcolicArray(const std::string &name, uintptr_t address, unsigned size,
                                                               const std::vector<unsigned char> &concreteBuffer,
                                                               std::string *varName) {
     assert(concreteBuffer.size() == size || concreteBuffer.size() == 0);
@@ -336,7 +336,7 @@ std::vector<ref<Expr>> S2EExecutionState::createConcolicArray(const std::string 
     // Add it to the set of symbolic expressions, to be able to generate
     // test cases later.
     // Dummy memory object
-    MemoryObject *mo = new MemoryObject(0, size, false, false, false, NULL);
+    MemoryObject *mo = new MemoryObject(address, size, false, false, false, NULL);
     mo->setName(sname);
 
     symbolics.push_back(std::make_pair(mo, array));
@@ -362,7 +362,7 @@ std::vector<ref<Expr>> S2EExecutionState::createConcolicArray(const std::string 
     return result;
 }
 
-std::vector<ref<Expr>> S2EExecutionState::createSymbolicArray(const std::string &name, unsigned size,
+std::vector<ref<Expr>> S2EExecutionState::createSymbolicArray(const std::string &name, uintptr_t address, unsigned size,
                                                               std::string *varName) {
     std::vector<unsigned char> concreteBuffer;
 
@@ -372,7 +372,7 @@ std::vector<ref<Expr>> S2EExecutionState::createSymbolicArray(const std::string 
         }
     }
 
-    return createConcolicArray(name, size, concreteBuffer, varName);
+    return createConcolicArray(name, address, size, concreteBuffer, varName);
 }
 
 /*
@@ -518,9 +518,9 @@ void S2EExecutionState::makeSymbolic(std::vector<ref<Expr>> &args, bool makeConc
         for (unsigned i = 0; i < sizeInBytes; ++i) {
             concreteData.push_back(cast<klee::ConstantExpr>(existingData[i])->getZExtValue(8));
         }
-        symb = createConcolicArray(labelStr, sizeInBytes, concreteData);
+        symb = createConcolicArray(labelStr, kleeAddress->getZExtValue(), sizeInBytes, concreteData);
     } else {
-        symb = createSymbolicArray(labelStr, sizeInBytes);
+        symb = createSymbolicArray(labelStr, kleeAddress->getZExtValue(), sizeInBytes);
     }
 
     kleeWriteMemory(kleeAddress, symb);


### PR DESCRIPTION
Currently the `MemoryObject` that is emitted with the `onSymbolicVariableCreation` signal has an address of `0`. Many times this address is known (e.g. in `BaseInstructions::makeSymbolic`) so we can set it to an appropriate value.