### PR TITLE
S2EExecutor: flush logs before calling exit()

### DIFF
--- a/src/S2E.cpp
+++ b/src/S2E.cpp
@@ -237,6 +237,11 @@ S2E::~S2E() {
 
     delete m_configFile;
 
+    // This is the last thing that will show in the debug log,
+    // it helps making sure that shutdown went fine.
+    getDebugStream() << "Engine terminated.\n";
+    flushOutputStreams();
+
     delete m_warningStream;
     delete m_infoStream;
     delete m_debugStream;

--- a/src/S2EExecutor.cpp
+++ b/src/S2EExecutor.cpp
@@ -1561,6 +1561,10 @@ ExecutionState *S2EExecutor::selectSearcherState(S2EExecutionState *state) {
         }
         m_deletedStates.clear();
         g_s2e->getCorePlugin()->onEngineShutdown.emit();
+
+        // Flush here just in case ~S2E() is not called (e.g., if atexit()
+        // shutdown handler was not called properly).
+        g_s2e->flushOutputStreams();
         exit(0);
     }
 


### PR DESCRIPTION
This way we'll get as much log content as possible even if S2E
does not shutdown properly.

Signed-off-by: Vitaly Chipounov <vitaly@cyberhaven.io>